### PR TITLE
Make web tracker more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ switch (experiment.engage(client.deviceId())) {
 }
 ```
 
+Tracking a page view.
+```typescript
+import { createClient, WebTracker, createWebTracker } from 'analytics-client';
+const client = createClient({ projectName: 'my-project' });
+createWebTracker(client).trackPageView();
+```
 
 ## Using without npm packages
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -4,17 +4,20 @@ import { Client } from './client';
  * WebTracker exposes an events tracking interface suitable for web apps.
  */
 export interface WebTracker {
-	trackPageView(name?: string): void;
+	trackPageView(prefix?: string, name?: string): void;
 }
 
 export function createWebTracker(client: Client): WebTracker {
 	return {
-		trackPageView(name?: string): void {
-			client.track(name ? name : 'Page View', {
-				current_url: window.location.href,
-				current_url_path: window.location.pathname,
-				metrics: getPageloadMetrics(),
-			});
+		trackPageView(prefix?: string, name?: string): void {
+			client.track(
+				`${prefix ? `[${prefix}] ` : ''}${name ? name : 'Page View'}`,
+				{
+					current_url: window.location.href,
+					current_url_path: window.location.pathname,
+					metrics: getPageloadMetrics(),
+				},
+			);
 		},
 	};
 }

--- a/test/web.test.ts
+++ b/test/web.test.ts
@@ -22,6 +22,9 @@ test('trackPageView', () => {
 	expect(passedData).toHaveProperty('current_url');
 	expect(passedData).toHaveProperty('current_url_path');
 
-	tracker.trackPageView('test event');
+	tracker.trackPageView('prefix');
+	expect(passedEventType).toStrictEqual('[prefix] Page View');
+
+	tracker.trackPageView('', 'test event');
 	expect(passedEventType).toStrictEqual('test event');
 });


### PR DESCRIPTION
Also, adds a page view tracking example to readme.

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>