### PR TITLE
Fix mixpanel dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "@types/amplitude-js": "^5.8.0",
     "amplitude-js": "^5.10.0",
-    "js-cookie": "^2.2.1"
+    "js-cookie": "^2.2.1",
+    "mixpanel-browser": "2.29.1"
   },
   "devDependencies": {
     "@balena/lint": "^4.0.1",
@@ -30,7 +31,6 @@
     "husky": "^3.0.9",
     "jest": "^24.9.0",
     "lint-staged": "^9.4.2",
-    "mixpanel-browser": "2.29.1",
     "ts-jest": "^24.1.0",
     "ts-loader": "^6.2.0",
     "typescript": "^3.8.3",


### PR DESCRIPTION
We rely on it in runtime in order to detect a device ID.

Chang-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>