### PR TITLE
Handle the case when user ID and device ID are equal

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -134,7 +134,10 @@ class DefaultClient implements Client {
 	}
 
 	linkDevices(userId: string, deviceIds: string[]): void {
-		const originalDeviceId = this.deviceId();
+		let finalDeviceId: string | null = this.deviceId();
+		if (finalDeviceId === userId) {
+			finalDeviceId = null;
+		}
 		this.setUserId(userId);
 
 		const identifyData = identifyObject();
@@ -143,12 +146,19 @@ class DefaultClient implements Client {
 		this.amplitudeInstance.identify(identifyData);
 
 		for (const deviceId of deviceIds) {
+			if (finalDeviceId == null && deviceId !== userId) {
+				finalDeviceId = deviceId;
+			}
 			this.amplitudeInstance.setDeviceId(deviceId);
 			this.amplitudeInstance.identify(identifyData);
 		}
 
-		// Continue reporting with the original device ID.
-		this.amplitudeInstance.setDeviceId(originalDeviceId);
+		// Continue reporting with the original device ID (if it's not equal to the user ID).
+		if (finalDeviceId != null) {
+			this.amplitudeInstance.setDeviceId(finalDeviceId);
+		} else {
+			this.amplitudeInstance.regenerateDeviceId();
+		}
 	}
 
 	track(eventType: string, props?: Properties): void {


### PR DESCRIPTION
Because we migrate from mixpanel to amplitude and use
the old distinct_id as a device ID, we can have situations when user ID
and device ID are set to the same value in Amplitude client.

However, the Amplitude service seems to ignore the user_id in such case.
This leads to some problems with reporting (if the same browser is used for
multiple users, we get events reported for a wrong user).

This change ensures we don't set device ID to a user ID value when we have
a choice (when multiple profiles are merged).

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>