### PR TITLE
Fix broken cookies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "@types/amplitude-js": "^5.8.0",
-    "amplitude-js": "^5.10.0",
+    "@types/amplitude-js": "5.11.0",
+    "amplitude-js": "5.11.0",
     "js-cookie": "^2.2.1",
     "mixpanel-browser": "2.29.1"
   },

--- a/src/client.ts
+++ b/src/client.ts
@@ -67,6 +67,7 @@ interface AmplitudeOverride {
 	cookieExpiration?: number;
 	includeReferrer?: boolean;
 	includeUtm?: boolean;
+	sameSiteCookie?: 'Lax' | 'Strict' | 'None';
 }
 
 const identifyObject = () =>
@@ -86,6 +87,7 @@ class DefaultClient implements Client {
 		amplConfig.cookieExpiration = COOKIES_TTL_DAYS;
 		amplConfig.includeReferrer = true;
 		amplConfig.includeUtm = true;
+		amplConfig.sameSiteCookie = 'Lax';
 
 		this.amplitudeInstance.init(config.projectName, undefined, amplConfig);
 		this.checkMixpanelUsage();


### PR DESCRIPTION
While working on integrating the latest client into our docs,
I noticed that Amplitude client is not able to create its cookie.
The issue is that in v5.11.0 they introduced the sameSiteCookie
property with default value None. However, it works only wih the
combination of setting Secure flag on a cookie in recent Chrome versions,
which is not done.

This change bumps the version, and fixes the behaviour setting
SameSite attribute to Lax. It matches the latest Amplitude lib
beehaviour (we don't update to the latest because of some breaking changes).

We also pin the client version to avoid such issues in the future.

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>