### PR TITLE
Changes on how device_id is treated on init

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,42 @@ Currently the only final destination is Amplitude. We have plans to support more
 npm install --save analytics-client
 ```
 
-## Usage
 
-Tracking a page view. The following reports an event named `[EFP] Page View` with default properties.
+## Client Initialization
+The first thing to do is create and initialize an `analytics client`.
+
+Since most of balena products are maintained on different components/repos (ie Hub, Marketing Site, Cloud, etc) we need to make sure that
+when someone navigates between components we can keep identifying it as a same id. 
+
+So to achieve that we will need to:
 
 ```typescript
-import { createClient, createWebTracker } from 'analytics-client';
+import { AnalyticsUrlParams, createClient} from 'analytics-client';
 
+const urlParamsHandler = new AnalyticsUrlParams();
+
+// This will handle any passed device id (d_id) param on the URL if it exists, save it on a cookie and return a "clean" query string without the d_id param
+const newQuery = urlParamsHandler.consumeUrlParameters(window.location.search) ?? null;
+
+// Then if there was any passed device id we can obtain them like this.
+// passedDeviceId is either the first d_id param passed on the URL or null
+const passedDeviceId = urlParamsHandler.getPassedDeviceId()
+
+// Now that we checked for any passed device_id we can proceed with creating and initializing the client
 const client = createClient({
     endpoint: 'data.balena-cloud.com', // use 'data.balena-staging.com' for testing
     projectName: 'balena-project', // unique identifier that analytics-backend expects
     componentName: 'etcher-featured-project', // short unique name of component
     componentVersion: require('./package.json').version, // (optional) automated version reporting
-});
+    deviceId: passedDeviceId,
+})
+```
+
+## Usage
+Tracking a page view. The following reports an event named `[EFP] Page View` with default properties.
+
+```typescript
+import {createWebTracker } from 'analytics-client';
 
 createWebTracker(client, 'EFP') // 2nd parameter defines the prefix of event names
     .trackPageView();

--- a/src/client.ts
+++ b/src/client.ts
@@ -60,6 +60,9 @@ export interface Config {
 
 	/** Optional config for Amplitude client. */
 	amplitude?: Exclude<AmplitudeOverride, amplitude.Config>;
+
+	/** Optional device_id for Amplitude client. */
+	deviceId?: string;
 }
 
 interface AmplitudeOverride {
@@ -88,6 +91,10 @@ class DefaultClient implements Client {
 		amplConfig.includeReferrer = true;
 		amplConfig.includeUtm = true;
 		amplConfig.sameSiteCookie = 'Lax';
+
+		if (config.deviceId) {
+			amplConfig.deviceId = config.deviceId;
+		}
 
 		this.amplitudeInstance.init(config.projectName, undefined, amplConfig);
 		this.checkMixpanelUsage();

--- a/src/url-params.ts
+++ b/src/url-params.ts
@@ -15,6 +15,7 @@ const deviceIdSeparator = /\s*,\s*/;
  */
 export class AnalyticsUrlParams {
 	private deviceIds: Set<string> = new Set();
+	private passedDeviceId: string | null;
 	private optOutRequsted: boolean = false;
 
 	constructor(private client?: Client) {
@@ -27,6 +28,8 @@ export class AnalyticsUrlParams {
 		currentDeviceId: string | null,
 	) {
 		const list = inputIdString ? inputIdString.split(deviceIdSeparator) : [];
+		this.passedDeviceId = list.length > 0 ? list[0] : null;
+
 		if (currentDeviceId) {
 			list.push(currentDeviceId);
 		}
@@ -96,6 +99,13 @@ export class AnalyticsUrlParams {
 		const res = new Set(this.deviceIds);
 		res.add(currentId);
 		return Array.from(res);
+	}
+
+	/**
+	 * @return an array of passed Device Ids via the URL param if there was any
+	 */
+	getPassedDeviceId() {
+		return this.passedDeviceId;
 	}
 
 	/**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
     "baseUrl": ".",
-    "keyofStringsOnly": true
+    "keyofStringsOnly": false
   },
   "include": [
     "index.ts",


### PR DESCRIPTION
With this changes the consumeUrlParams dont override the client
device_id with the passed one. Instead it returns the passed one
if exists and the clean queryParams string.
Then the amplitude Config is now allowed to recieve a device_id.
So then the client creation happens, if a device_id is passed on Config,
(which should be the one obtained from consumeUrlParams now),
it initiates the client with that device_id, and if not, it initiates
with no device_id, so it creates one.

Since this changes modifies some of the base logic of the
analytics-client, other components implementation should be
revisited to comply with these changes.

Change-type: Major
Signed-off-by: Ezequiel Boehler ezequiel@balena.io