### PR TITLE
Created new declareClient function un url-params

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ const client = createClient({
     componentVersion: require('./package.json').version, // (optional) automated version reporting
     deviceId: passedDeviceId,
 })
+
+// A newly created client is passed to the `AnalyticsUrlParams` to make it fully functional.
+urlParamsHandler.setClient(client);
 ```
 
 ## Usage

--- a/src/url-params.ts
+++ b/src/url-params.ts
@@ -103,12 +103,24 @@ export class AnalyticsUrlParams {
 		if (this.client) {
 			throw new Error('Client is already set');
 		}
-		const newDeviceId = this.setDeviceIds(null, client.deviceId());
-		if (newDeviceId != null) {
-			client.setDeviceId(newDeviceId);
+		if (
+			this.getPassedDeviceId() &&
+			this.getPassedDeviceId() !== client.deviceId()
+		) {
+			const newDeviceId = this.setDeviceIds(null, client.deviceId());
+			if (newDeviceId != null) {
+				client.setDeviceId(newDeviceId);
+			}
+		}
+		if (this.sessionId && client.sessionId() !== this.sessionId) {
+			client.setSessionId(this.sessionId);
 		}
 		this.sessionId = client.sessionId();
 		this.client = client;
+	}
+
+	getClient() {
+		return this.client;
 	}
 
 	/**


### PR DESCRIPTION
This new function expects a a client to be passed, and sets this client
on the AnalyticsUrlParams class for it to be used on functions such as
getSessionId, getQueryString and so on.

Without it, those functions wont work with the new way to init
the analytics client.

Change-type: Minor
Signed-off-by: Ezequiel Boehler ezequiel@balena.io