### PR TITLE
Added unsetParamsReferrerOnNewSession to client

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -97,6 +97,7 @@ class DefaultClient implements Client {
 		amplConfig.includeReferrer = true;
 		amplConfig.includeUtm = true;
 		amplConfig.sameSiteCookie = 'Lax';
+		amplConfig.unsetParamsReferrerOnNewSession = true;
 
 		if (config.deviceId) {
 			amplConfig.deviceId = config.deviceId;


### PR DESCRIPTION
With this config variable set to true, now new sessions that
dont include referrer or UTM values will be set to null or none
instead of carrying over previous referrers. This should help us
to properly identify trends and behaviour of referrers since
its more transparent than the previous behaviour.

Change-type: Minor
Signed-off-by: Ezequiel Boehler ezequiel@balena.io