### PR TITLE
Add Amplitude Engagement SDK back

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,8 @@ module.exports = {
 		'^.+\\.tsx?$': 'ts-jest',
 	},
 	testEnvironment: 'jsdom',
+	moduleNameMapper: {
+		'@amplitude/engagement-browser':
+			'<rootDir>/test/mocks/amplitude/engagement-browser.js',
+	},
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   ],
   "dependencies": {
     "@amplitude/analytics-browser": "^2.16.0",
+    "@amplitude/engagement-browser": "^0.0.6",
     "@amplitude/plugin-user-agent-enrichment-browser": "^1.0.1",
     "js-cookie": "^3.0.1"
   },

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,5 @@
 import { Identify, Types, createInstance } from '@amplitude/analytics-browser';
+import { plugin as engagementPlugin } from '@amplitude/engagement-browser';
 import { userAgentEnrichmentPlugin } from '@amplitude/plugin-user-agent-enrichment-browser';
 import { version } from '../package.json';
 import { getAmplitudeEndpoint } from './common';
@@ -90,6 +91,7 @@ class DefaultClient implements Client {
 
 	constructor(config: Config) {
 		this.amplitudeInstance = createInstance();
+		this.amplitudeInstance.add(engagementPlugin());
 		this.amplitudeInstance.add(userAgentEnrichmentPlugin());
 
 		const amplConfig: Types.BrowserOptions = Object.assign(


### PR DESCRIPTION
We had to temporarily remove the Engagement SDK because we did the implementation wrong and it was throwing errors in the console that would delay the sending of events to Amplitude. This PR adds it back.

See: https://balena.fibery.io/Work/Improvement/Add-the-Amplitude-Guides-and-Surveys-SDK-to-the-dashboard-2729
